### PR TITLE
New placeholder management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":"nilportugues/sql-query-builder",
+    "name":"nitricware/sql-query-builder",
     "description":"An elegant lightweight and efficient SQL QueryInterface BuilderInterface supporting bindings and complicated query generation.",
     "keywords": [ "sql", "mysql", "query", "builder", "query builder", "orm"],
     "type":"library",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,12 @@
             "email":"woody.gilk@gmail.com",
             "homepage":"http://shadowhand.me/",
             "role":"Contributor"
+        },
+        {
+            "name":"Kurt Höblinger",
+            "email":"office@nitricware.com",
+            "homepage":"http://nitricware.com",
+            "role":"Contributor"
         }
     ],
     "autoload":{

--- a/src/Builder/Syntax/PlaceholderWriter.php
+++ b/src/Builder/Syntax/PlaceholderWriter.php
@@ -52,7 +52,11 @@ class PlaceholderWriter
     public function add($value)
     {
         if (in_array($value, $this->placeholders)) {
-            $placeholderKey = ':'.$value.$this->counter;
+            $c = 0;
+            foreach ($this->placeholders as $p) {
+                if ($p == $value) $c++;
+            }
+            $placeholderKey = ':'.$value.$c;
         } else {
             $placeholderKey = ':'.$value;
         }

--- a/src/Builder/Syntax/PlaceholderWriter.php
+++ b/src/Builder/Syntax/PlaceholderWriter.php
@@ -51,7 +51,12 @@ class PlaceholderWriter
      */
     public function add($value)
     {
-        $placeholderKey = ':v'.$this->counter;
+        if (in_array($value, $this->placeholders)) {
+            $placeholderKey = ':'.$value.$this->counter;
+        } else {
+            $placeholderKey = ':'.$value;
+        }
+        
         $this->placeholders[$placeholderKey] = $this->setValidSqlValue($value);
 
         ++$this->counter;


### PR DESCRIPTION
Hy,

I couldn't figure out what the value parameter is used for. So I thought, why not use it for something I need. Maybe someone needs that too. *Maybe I use the software all wrong...*

**The current behaviour is this:** 
```php
$q = $this->qb->select()->setTable("someTable")->where()->equals("id", 12345)->end();
$s = $this->qb->write($q);
// $s looks like this: SELECT someTable.* from someTable WHERE id = :v1
$s = parent::prepare($s);
// Context: the surrounding class extends PDO
$s->bindValue(":id", $id);
$s->execute();
$r = $s->fetch();
```

**New behaviour:**
```php
$q = $this->qb->select()->setTable("someTable")->where()->equals("id", "myID")->end();
$s = $this->qb->write($q);
// $s looks like this: SELECT someTable.* from someTable WHERE id = :myID
$s = parent::prepare($s);
// Context: the surrounding class extends PDO
$s->bindValue(":myID", $id);
$s->execute();
$r = $s->fetch();
```

Note how the placeholder changed from the generic :v1 to a useable (even if the query was generated dymically) :myID - if (for whatever reason) myID was used twice, the placeholder changes to :myID1 and so on.