### PR TITLE
add setWhere method

### DIFF
--- a/src/Manipulation/AbstractBaseQuery.php
+++ b/src/Manipulation/AbstractBaseQuery.php
@@ -153,6 +153,18 @@ abstract class AbstractBaseQuery implements QueryInterface, QueryPartInterface
     }
 
     /**
+     * @param Where $where
+     *
+     * @return $this
+     */
+    public function setWhere(Where $where)
+    {
+        $this->where = $where;
+
+        return $this;
+    }
+
+    /**
      * @return Table
      */
     public function getTable()


### PR DESCRIPTION
use case : 

`
$v = explode(',', $filter['value']);

$where = $query->where()->subWhere("OR");

foreach ($v as $item) {

  $where->equals($op_field, $item);

}

$query = $query->setWhere($where);

`
so if have a setWhere function , it will very easy :