### PR TITLE
Do not filter values in AbstractCreationalQuery

### DIFF
--- a/src/Manipulation/AbstractCreationalQuery.php
+++ b/src/Manipulation/AbstractCreationalQuery.php
@@ -50,12 +50,7 @@ abstract class AbstractCreationalQuery extends AbstractBaseQuery
      */
     public function setValues(array $values)
     {
-        $this->values = \array_filter($values, function($value) {
-            if (is_int($value)) {
-                return true;
-            }
-            return $value;
-        });
+        $this->values = $values;
         
         return $this;
     }

--- a/tests/Manipulation/InsertTest.php
+++ b/tests/Manipulation/InsertTest.php
@@ -62,4 +62,16 @@ class InsertTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('NilPortugues\Sql\QueryBuilder\Syntax\Column', $columns[0]);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldSetNullableValues()
+    {
+        $values = ['user_id' => 1, 'description' => null, 'isVisible' => false];
+
+        $this->query->setValues($values);
+
+        $this->assertSame($values, $this->query->getValues());
+    }
 }

--- a/tests/Manipulation/UpdateTest.php
+++ b/tests/Manipulation/UpdateTest.php
@@ -58,4 +58,16 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($values, $this->query->getValues());
     }
+
+    /**
+     * @test
+     */
+    public function itShouldSetNullableValues()
+    {
+        $values = ['user_id' => 1, 'description' => null, 'isVisible' => false];
+
+        $this->query->setValues($values);
+
+        $this->assertSame($values, $this->query->getValues());
+    }
 }


### PR DESCRIPTION

Hi @nilportugues ! 

Thank you for your great package, I really enjoy using it.

I have a problem with a query when my query should contain something which is not `==` to true (except the `"0"`).
For example, I have a table which has the next structure: 
```sql
CREATE TABLE IF NOT EXISTS `Example`
(
    `Id`          int(1)       NOT NULL,
    `Tittle`      VARCHAR(255) NOT NULL,
    `Description` LONGTEXT     NULL DEFAULT NULL,
    `IsSomething` bool not null default TRUE,

) ENGINE = InnoDB;
```
The problem is the description was set you can't set it to null anymore, and also you can't change `IsSomething` on `false`.

Reproduce the issue:
```php
$genericBuilder = new GenericBuilder();
echo $genericBuilder->write(
    $genericBuilder->update()
        ->setTable('Example')
        ->setValues([
            'Title' => "example title",
            'isSomething' => false,
            'Description' => null
        ])
        ->where()
        ->equals('id', 5)
        ->end()
);
// ACTUAL: UPDATE Example SET  Example.Title = :v1 WHERE (Example.id = :v2)
// EXPECTED: UPDATE Example SET  Example.Title = :v1, Example.isSomething = :v2, Example.Description = :v3 WHERE (Example.id = :v4)
```

The issue was occurred before in the [issue #82](https://github.com/nilportugues/php-sql-query-builder/issues/82) but wasn't completely solve, only the integer case.
Also a related issue: #92 

