### PR TITLE
Do not insert null string in sql query if string is '0'

### DIFF
--- a/src/Builder/Syntax/PlaceholderWriter.php
+++ b/src/Builder/Syntax/PlaceholderWriter.php
@@ -80,7 +80,7 @@ class PlaceholderWriter
      */
     protected function writeNullSqlString($value)
     {
-        if (\is_null($value) || (\is_string($value) && empty($value))) {
+        if ($value === null || (\is_string($value) && trim($value) === '')) {
             $value = $this->writeNull();
         }
 

--- a/tests/Builder/Syntax/PlaceholderWriterTest.php
+++ b/tests/Builder/Syntax/PlaceholderWriterTest.php
@@ -62,6 +62,15 @@ class PlaceholderWriterTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function itShouldTranslatePhpStringToSqlString()
+    {
+        $this->writer->add('0');
+
+        $this->assertEquals(array(':v1' => '0'), $this->writer->get());
+    }
+    /**
+     * @test
+     */
     public function itShouldTranslatePhpBoolToSqlBoolValue()
     {
         $this->writer->add(true);


### PR DESCRIPTION

Hello @nilportugues!
 I run into an issue during using the query builder, I have next table structure.
```sql
CREATE TABLE IF NOT EXISTS `Table` (
  `UserID` int(1) NOT NULL,
  `EnumValue` ENUM("0", "1", "2") NOT NULL
) ENGINE = InnoDB;

```
If I'll use "0" as the value of enums (it says for status), the result will be "NULL" in the query.
Code to reproduce the issue
```PHP
$genericQueryBuilder = new \NilPortugues\Sql\QueryBuilder\Builder\GenericBuilder();

$query = $genericQueryBuilder->update()
    ->setTable('table')
    ->setValues(
        [
            'EnumValue' => '0'
        ]
    )->where()
    ->equals('UserId', 1)
    ->end();
echo $genericQueryBuilder->write($query);
//UPDATE table SET  table.EnumValue = :v1 WHERE (table.UserId = :v2)
var_dump($genericQueryBuilder->getValues());
/*
array(2) {
  [":v1"]=>
  string(1) "NULL"
  [":v2"]=>
  int(1)
}

*/
```
As you can see '0' becomes NULL in the end, and it isn't a valid enum value in this case
expected values would be 
```php
/*
array(2) {
  [":v1"]=>
  string(1) "0"
  [":v2"]=>
  int(1)
}
*/
```