### PR TITLE
hardening columnAlias removal

### DIFF
--- a/src/Manipulation/ColumnQuery.php
+++ b/src/Manipulation/ColumnQuery.php
@@ -200,7 +200,7 @@ class ColumnQuery
         $count .= ')';
 
         if (isset($alias) && \strlen($alias) > 0) {
-            $count .= ' AS "'.$alias.'"';
+            $count .= ' AS "' . $alias . '"';
         }
 
         $this->columns = array($count);

--- a/src/Syntax/SyntaxFactory.php
+++ b/src/Syntax/SyntaxFactory.php
@@ -60,7 +60,7 @@ final class SyntaxFactory
         $columnAlias = \array_keys($argument);
         $columnAlias = $columnAlias[0];
 
-        if (\is_numeric($columnAlias) || \strpos($columnName, '*') !== false) {
+        if (\is_numeric($columnAlias) || (\strpos($columnName, '*') !== false && \strlen(\trim($columnName)==1))) {
             $columnAlias = null;
         }
 


### PR DESCRIPTION
This fix helps to retain the columnAlias for columns like: 
`SUM(Column1*Column2) as myAlias `
if build via 
`$objQuery->setFunctionAsColumn('SUM', ['Column1*Column2'], 'myAlias');`

So far the alias will be removed because a * is found.
Now it also checks if length of columnName == 1
