### PR TITLE
hardening columnAlias remove

### DIFF
--- a/src/Manipulation/ColumnQuery.php
+++ b/src/Manipulation/ColumnQuery.php
@@ -200,7 +200,7 @@ class ColumnQuery
         $count .= ')';
 
         if (isset($alias) && \strlen($alias) > 0) {
-            $count .= ' AS "' . $alias . '"';
+            $count .= ' AS "'.$alias.'"';
         }
 
         $this->columns = array($count);

--- a/src/Manipulation/ColumnQuery.php
+++ b/src/Manipulation/ColumnQuery.php
@@ -200,7 +200,7 @@ class ColumnQuery
         $count .= ')';
 
         if (isset($alias) && \strlen($alias) > 0) {
-            $count .= ' AS "'.$alias.'"';
+            $count .= ' AS "' . $alias . '"';
         }
 
         $this->columns = array($count);

--- a/src/Syntax/SyntaxFactory.php
+++ b/src/Syntax/SyntaxFactory.php
@@ -60,7 +60,7 @@ final class SyntaxFactory
         $columnAlias = \array_keys($argument);
         $columnAlias = $columnAlias[0];
 
-        if (\is_numeric($columnAlias) || (\strpos($columnName, '*') !== false && \strlen(\trim($columnName)==1))) {
+        if (\is_numeric($columnAlias) || (\strpos($columnName, '*') !== false && \strlen(\trim($columnName))==1)) {
             $columnAlias = null;
         }
 

--- a/src/Syntax/SyntaxFactory.php
+++ b/src/Syntax/SyntaxFactory.php
@@ -60,7 +60,7 @@ final class SyntaxFactory
         $columnAlias = \array_keys($argument);
         $columnAlias = $columnAlias[0];
 
-        if (\is_numeric($columnAlias) || \strpos($columnName, '*') !== false) {
+        if (\is_numeric($columnAlias) || (\strpos($columnName, '*') !== false && \strlen(\trim($columnName)==1))) {
             $columnAlias = null;
         }
 


### PR DESCRIPTION
So far the column alias will be removed, if a * is found in column name.
This prevents for selecting the following:

`$objQuery->setFunctionAsColum('SUM', ['Column1*Column2'], 'my_alias');`

Now this can be done.
Thank you.