### PR TITLE
Disable table name prepend  in group by

### DIFF
--- a/src/Builder/Syntax/ColumnWriter.php
+++ b/src/Builder/Syntax/ColumnWriter.php
@@ -151,11 +151,15 @@ class ColumnWriter
      */
     public function writeColumn(Column $column)
     {
-        $alias = $column->getTable()->getAlias();
-        $table = ($alias) ? $this->writer->writeTableAlias($alias) : $this->writer->writeTable($column->getTable());
+        if ( $column->getDisableTablePrependInGroup() === false ) {
+            $alias = $column->getTable()->getAlias();
+            $table = ($alias) ? $this->writer->writeTableAlias($alias) : $this->writer->writeTable($column->getTable());
 
-        $columnString = (empty($table)) ? '' : "{$table}.";
-        $columnString .= $this->writer->writeColumnName($column);
+            $columnString = (empty($table)) ? '' : "{$table}.";
+            $columnString .= $this->writer->writeColumnName($column);
+        } else {
+            $columnString = $this->writer->writeColumnName($column);
+        }
 
         return $columnString;
     }

--- a/src/Builder/Syntax/SelectWriter.php
+++ b/src/Builder/Syntax/SelectWriter.php
@@ -238,20 +238,25 @@ class SelectWriter extends AbstractBaseWriter
 
     /**
      * @param Select $select
-     * @param array  $parts
+     * @param array $parts
      *
      * @return $this
      */
     public function writeSelectGroupBy(Select $select, array &$parts)
     {
-        $groupBy = $this->writeSelectAggrupation(
-            $select,
-            $this->columnWriter,
-            'getGroupBy',
-            'writeColumn',
-            ', ',
-            'GROUP BY '
-        );
+        $groupBy = '';
+        $columns = $select->getGroupBy();
+        $columnWriter = $this->columnWriter;
+        if ( !empty($columns) ) {
+            \array_walk(
+                $columns,
+                function (&$column) use ($select, $columnWriter) {
+                    $column->setDisableTablePrependInGroup($select->getDisableTablePrepend());
+                    $column = $columnWriter->writeColumn($column);
+                }
+            );
+            $groupBy = 'GROUP BY' . implode(',', $columns);
+        }
 
         $parts = \array_merge($parts, [$groupBy]);
 

--- a/src/Manipulation/Select.php
+++ b/src/Manipulation/Select.php
@@ -531,16 +531,27 @@ class Select extends AbstractBaseQuery
     /**
      * @param string $column
      * @param string $direction
-     * @param null   $table
+     * @param null $table
      *
      * @return $this
      */
     public function orderBy($column, $direction = OrderBy::ASC, $table = null)
     {
         $current = parent::orderBy($column, $direction, $table);
-        if ($this->getParentQuery() != null) {
+        if ( $this->getParentQuery() != null ) {
             $this->getParentQuery()->orderBy($column, $direction, \is_null($table) ? $this->getTable() : $table);
         }
         return $current;
+    }
+
+    public function setDisableTablePrepend($disableTablePrepend=false)
+    {
+        $this->disableTablePrepend = $disableTablePrepend;
+        return $this;
+    }
+
+    public function getDisableTablePrepend()
+    {
+        return $this->disableTablePrepend;
     }
 }

--- a/src/Syntax/Column.php
+++ b/src/Syntax/Column.php
@@ -34,6 +34,8 @@ class Column implements QueryPartInterface
      */
     protected $alias;
 
+    protected $disableTablePrependInGroup = false;
+
     /**
      * @param string $name
      * @param string $table
@@ -135,5 +137,19 @@ class Column implements QueryPartInterface
     public function isAll()
     {
         return $this->getName() == self::ALL;
+    }
+
+    /** Disable prepend table name in group by
+     * @param $disableTablePrependInGroup
+     * @return void
+     */
+    public function setDisableTablePrependInGroup($disableTablePrependInGroup)
+    {
+        $this->disableTablePrependInGroup = (bool)$disableTablePrependInGroup;
+    }
+
+    public function getDisableTablePrependInGroup()
+    {
+        return $this->disableTablePrependInGroup;
     }
 }


### PR DESCRIPTION
Added disabling of substitution of table names and aliases in field names for grouping.
To be able to group by function fields or aliases.