### PR TITLE
fix: Translate only type-safe null to sql null

### DIFF
--- a/src/Builder/Syntax/PlaceholderWriter.php
+++ b/src/Builder/Syntax/PlaceholderWriter.php
@@ -80,8 +80,10 @@ class PlaceholderWriter
      */
     protected function writeNullSqlString($value)
     {
-        if (\is_null($value) || (\is_string($value) && empty($value))) {
+        if (\is_null($value)) {
             $value = $this->writeNull();
+        } elseif ((\is_string($value) && empty($value))) {
+            $value = '';
         }
 
         return $value;
@@ -92,7 +94,7 @@ class PlaceholderWriter
      */
     protected function writeNull()
     {
-        return 'NULL';
+        return NULL;
     }
 
     /**

--- a/tests/Builder/Syntax/PlaceholderWriterTest.php
+++ b/tests/Builder/Syntax/PlaceholderWriterTest.php
@@ -56,7 +56,7 @@ class PlaceholderWriterTest extends \PHPUnit_Framework_TestCase
         $this->writer->add('');
         $this->writer->add(null);
 
-        $this->assertEquals(array(':v1' => 'NULL', ':v2' => 'NULL'), $this->writer->get());
+        $this->assertEquals(array(':v1' => '', ':v2' => null), $this->writer->get());
     }
 
     /**


### PR DESCRIPTION
When using equals / notEquals method with an empty string it keeps the empty string instead of replacing with null.
Previously it substituted the empty string with 'NULL' string.
This PR fixes issue https://github.com/nilportugues/php-sql-query-builder/issues/106

- [x] Tests updated and run
